### PR TITLE
writable comment, ssh pub key split rather than gsub

### DIFF
--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -109,7 +109,7 @@ class SSHKey
     end
 
     def decoded_key(key)
-      Base64.decode64(key.split(/\s/)[1].chomp)
+      Base64.decode64(key.gsub(/^(ssh-[dr]s[as]\s+)|(\s+.+\@.+)|\n/, ''))
     end
 
     def fingerprint_regex


### PR DESCRIPTION
Made comment writable, no reason a user can't add the comment to their public key after it's already generated.

Changed the way ssh public keys are split in decode_key, removing both ssh-(rs|ds)a and the trailing comment.  Makes it easier to just 'drop-in' a public ssh key on the fly.

Thanks!
