### PR TITLE
Add public class method ssh_public_key_bits

### DIFF
--- a/lib/sshkey/exception.rb
+++ b/lib/sshkey/exception.rb
@@ -1,0 +1,3 @@
+class SSHKey
+  class PublicKeyError < StandardError; end
+end

--- a/test/sshkey_test.rb
+++ b/test/sshkey_test.rb
@@ -259,6 +259,7 @@ EOF
     expected3 = "ssh-dss #{SSH_PUBLIC_KEY3} me@example.com"
     expected4 = "ssh-rsa #{SSH_PUBLIC_KEY1}"
     expected5 = %Q{from="trusted.eng.cam.ac.uk",no-port-forwarding,no-pty ssh-rsa #{SSH_PUBLIC_KEY1}}
+    invalid1  = "#{SSH_PUBLIC_KEY1} me@example.com"
 
     assert_equal 2048, SSHKey.ssh_public_key_bits(expected1)
     assert_equal 2048, SSHKey.ssh_public_key_bits(expected2)
@@ -267,8 +268,13 @@ EOF
     assert_equal 2048, SSHKey.ssh_public_key_bits(expected5)
     assert_equal 512,  SSHKey.ssh_public_key_bits(SSHKey.generate(:bits => 512).ssh_public_key)
 
-    assert_raises(RuntimeError) { SSHKey.ssh_public_key_bits( expected1[0..-20] ) }
-    assert_raises(NoMethodError) { SSHKey.ssh_public_key_bits( expected1.gsub('A','.') ) }
+    exception1 = assert_raises(SSHKey::PublicKeyError) { SSHKey.ssh_public_key_bits( expected1.gsub('A','.') ) }
+    exception2 = assert_raises(SSHKey::PublicKeyError) { SSHKey.ssh_public_key_bits( expected1[0..-20] ) }
+    exception3 = assert_raises(SSHKey::PublicKeyError) { SSHKey.ssh_public_key_bits(invalid1) }
+
+    assert_equal( "validation error",          exception1.message )
+    assert_equal( "byte array too short",      exception2.message )
+    assert_equal( "cannot determine key type", exception3.message )
   end
 
   def test_exponent


### PR DESCRIPTION
I've found it useful to pull out public SSH Key bits.  To that end, I broke out the logic of `::valid_ssh_public_key?` into a private method and use that data for both validation and `::ssh_public_key_bits`.  In both cases, if a key is invalid, false is returned.

The compressed syntax on line [#62](#L0R62) can be off-putting to some.  If it's a problem, I'll break it out onto two lines and rebase.

I did run the build through Travis, but I'm an error against [ruby-head](https://travis-ci.org/dacamp/sshkey/jobs/11004091).  Seems like it's a [known issue](https://github.com/travis-ci/travis-ci/issues/1195) though.  Might not be a bad idea to configure ruby-head as an allowable failure.

If you think this addition is useful, please review it and let me know if you have any questions.  Thanks!
