### PR TITLE
Travis builds against ruby-head should fail gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ rvm:
   - jruby-head
   - rbx-18mode
   - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
Seems most folks allow travis builds against ruby-head to gracefully fail, here's the closed travis-ci [issue](https://github.com/travis-ci/travis-ci/issues/1195).

I ran across this during another feature build where travis would [error](https://travis-ci.org/dacamp/sshkey/jobs/11004291#L1) because of of the inability to install bundler.

``` bash
$ git clone --depth=50 --branch=master git://github.com/dacamp/sshkey.git dacamp/sshkey
$ git checkout -qf 91a5b54f9b8bbebe23bee382404a9f1eba3d55bb
$ rvm use ruby-head --install --binary --fuzzy
Using /home/travis/.rvm/gems/ruby-head-s52a802a4285647a8dfce77c0dd5ded1c4532fd73
$ export BUNDLE_GEMFILE=$PWD/Gemfile
$ gem query --local | grep bundler >/dev/null || gem install bundler
ERROR:  Could not find a valid gem 'bundler' (>= 0), here is why:
          Unable to download data from https://rubygems.org/ - no such name (https://rubygems.org/latest_specs.4.8.gz)
The command "gem install bundler" failed and exited with 2 during setup.
Your build has been stopped.
```

I think you'll get a more realistic CI view this way, but fully understand if you'd like to keep ruby-head as a hard failure.  Thanks!
