### PR TITLE
Validation for multiline keys

### DIFF
--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -54,6 +54,17 @@ class SSHKey
       false
     end
 
+    # Validate multiline SSH public keys (e.g. authorized_keys)
+    #
+    # Returns true or false depending on the validity of the public keys provided
+    #
+    # ==== Parameters
+    # * ssh_public_key<~String> - "ssh-rsa AAAAB3NzaC1yc2EA....\nssh-rsa AAAAB3NzaC1yc2EA...."
+    #
+    def valid_multiline_public_keys?(ssh_public_keys)
+      ssh_public_keys.split("\n").all? {|k| valid_ssh_public_key?(k) }
+    end
+
     # Bits
     #
     # Returns ssh public key bits or false depending on the validity of the public key provided
@@ -121,6 +132,8 @@ class SSHKey
     end
 
     def parse_ssh_public_key(public_key)
+      raise PublicKeyError, "invalid newlines" if public_key =~ /\n(?!$)/
+
       parsed = public_key.split(" ")
       parsed.each_with_index do |el, index|
         return parsed[index..(index+1)] if SSH_TYPES.invert[el]

--- a/test/sshkey_test.rb
+++ b/test/sshkey_test.rb
@@ -253,6 +253,33 @@ EOF
     assert !SSHKey.valid_ssh_public_key?(invalid5)
   end
 
+  def test_ssh_public_key_validation_with_newlines
+    expected1 = "ssh-rsa #{SSH_PUBLIC_KEY1}\n"
+    invalid1  = "ssh-rsa #{SSH_PUBLIC_KEY1}\nme@example.com"
+    invalid2  = "ssh-rsa #{SSH_PUBLIC_KEY1}\n me@example.com"
+    invalid3  = "ssh-rsa #{SSH_PUBLIC_KEY1} \nme@example.com"
+
+    assert SSHKey.valid_ssh_public_key?(expected1)
+
+    assert !SSHKey.valid_ssh_public_key?(invalid1)
+    assert !SSHKey.valid_ssh_public_key?(invalid2)
+    assert !SSHKey.valid_ssh_public_key?(invalid3)
+  end
+
+  def test_multiline_public_key_validation
+    key1    = "ssh-rsa #{SSH_PUBLIC_KEY1} me@example.com\n"
+    key2    = "ssh-rsa #{SSH_PUBLIC_KEY2} me@example.com\n"
+    key3    = "ssh-dss #{SSH_PUBLIC_KEY3} me@example.com\n"
+    invalid = "invalid\n"
+
+    valid_keys = [key1, key2, key3].join
+    invalid_keys = [key1, key2, invalid, key3].join
+
+    assert SSHKey.valid_multiline_public_keys?(valid_keys)
+
+    assert !SSHKey.valid_multiline_public_keys?(invalid_keys)
+  end
+
   def test_ssh_public_key_bits
     expected1 = "ssh-rsa #{SSH_PUBLIC_KEY1} me@example.com"
     expected2 = "ssh-rsa #{SSH_PUBLIC_KEY2} me@example.com"


### PR DESCRIPTION
From #14

This pull request addresses two issues.
- Fix public key validation with newlines
- Add a method to validate multiline public keys for authorized_keys
