### PR TITLE
Supress warnings

### DIFF
--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -121,7 +121,7 @@ class SSHKey
     def ssh_public_key_to_ssh2_public_key(ssh_public_key, headers = nil)
       raise PublicKeyError, "invalid ssh public key" unless SSHKey.valid_ssh_public_key?(ssh_public_key)
 
-      source_format, source_key = parse_ssh_public_key(ssh_public_key)
+      _source_format, source_key = parse_ssh_public_key(ssh_public_key)
 
       # Add a 'Comment' Header Field unless others are explicitly passed in
       if source_comment = ssh_public_key.split(source_key)[1]

--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -35,7 +35,7 @@ class SSHKey
       default_bits = type == "rsa" ? 2048 : 1024
 
       bits   = options[:bits] || default_bits
-      cipher = OpenSSL::Cipher::Cipher.new("AES-128-CBC") if options[:passphrase]
+      cipher = OpenSSL::Cipher.new("AES-128-CBC") if options[:passphrase]
 
       case type.downcase
       when "rsa" then new(OpenSSL::PKey::RSA.generate(bits).to_pem(cipher, options[:passphrase]), options)
@@ -231,7 +231,7 @@ class SSHKey
   # If no passphrase is set, returns the unencrypted private key
   def encrypted_private_key
     return private_key unless passphrase
-    key_object.to_pem(OpenSSL::Cipher::Cipher.new("AES-128-CBC"), passphrase)
+    key_object.to_pem(OpenSSL::Cipher.new("AES-128-CBC"), passphrase)
   end
 
   # Fetch the RSA/DSA public key

--- a/test/sshkey_test.rb
+++ b/test/sshkey_test.rb
@@ -382,7 +382,7 @@ EOF
     assert_equal(SSH2_PUBLIC_KEY2, SSHKey.ssh_public_key_to_ssh2_public_key(public_key2))
     assert_equal(SSH2_PUBLIC_KEY2, SSHKey.ssh_public_key_to_ssh2_public_key(public_key2, {}))
     assert_equal(SSH2_PUBLIC_KEY3, SSHKey.ssh_public_key_to_ssh2_public_key(public_key3, {'Comment' => '1024-bit DSA with provided comment', 'x-private-use-header' => 'some value that is long enough to go to wrap around to a new line.'}))
-end
+  end
 
   def test_exponent
     assert_equal 35, @key1.key_object.e.to_i

--- a/test/sshkey_test.rb
+++ b/test/sshkey_test.rb
@@ -261,9 +261,6 @@ EOF
     expected1 = SSH2_PUBLIC_KEY1
     expected2 = SSH2_PUBLIC_KEY2
     expected3 = SSH2_PUBLIC_KEY3
-    public_key1 = "ssh-rsa #{SSH_PUBLIC_KEY1} me@example.com"
-    public_key2 = "ssh-rsa #{SSH_PUBLIC_KEY2}"
-    public_key3 = "ssh-rsa #{SSH_PUBLIC_KEY3} 1024-bit DSA with provided comment"
 
     assert_equal expected1, @key1.ssh2_public_key
     assert_equal expected2, @key2.ssh2_public_key({})


### PR DESCRIPTION
MRI adds some warnings to this repository if Ruby runs with `-w` option.
This change suppresses the warnings.