### PR TITLE
Remove rubyforge_project from specification

### DIFF
--- a/sshkey.gemspec
+++ b/sshkey.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = %q{Generate private/public SSH keypairs using pure Ruby}
   s.licenses    = ["MIT"]
 
-  s.rubyforge_project = "sshkey"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Rubyforge is long gone, but leaving this in the specification will generate a warning with Rubygems 3.1+.