### PR TITLE
OpenSSL 3.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tested / supported on CRuby 2.0.0+ and JRuby.
 
 ### Generate a new key
 
-When generating a new keypair the default key type is 2048-bit RSA, but you can supply the `type` (RSA or DSA) and `bits` in the options.
+When generating a new keypair the default key type is 2048-bit RSA, but you can supply the `type` (RSA or DSA or ECDSA) and `bits` in the options.
 You can also (optionally) supply a `comment` or `passphrase`.
 
 ```ruby
@@ -32,7 +32,7 @@ k = SSHKey.generate(
 
 ### Use your existing key
 
-Return an SSHKey object from an existing RSA or DSA private key (provided as a string).
+Return an SSHKey object from an existing RSA or DSA or ECDSA private key (provided as a string).
 
 ```ruby
 f = File.read(File.expand_path("~/.ssh/id_rsa"))
@@ -43,7 +43,7 @@ k = SSHKey.new(f, comment: "foo@bar.com")
 
 #### Private and public keys
 
-Fetch the private and public keys as strings. Note that the `public_key` is the RSA or DSA public key, not an SSH public key.
+Fetch the private and public keys as strings. Note that the `public_key` is the RSA or DSA or ECDSA public key, not an SSH public key.
 
 ```ruby
 k.private_key
@@ -161,7 +161,7 @@ puts k.randomart
 
 #### Original OpenSSL key object
 
-Return the original [OpenSSL::PKey::RSA](http://www.ruby-doc.org/stdlib/libdoc/openssl/rdoc/classes/OpenSSL/PKey/RSA.html) or [OpenSSL::PKey::DSA](http://www.ruby-doc.org/stdlib/libdoc/openssl/rdoc/classes/OpenSSL/PKey/DSA.html) object.
+Return the original [OpenSSL::PKey::RSA](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/PKey/RSA.html) or [OpenSSL::PKey::DSA](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/PKey/DSA.html) or [OpenSSL::PKey::EC](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/PKey/EC.html)object.
 
 ```ruby
 k.key_object

--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -97,18 +97,31 @@ class SSHKey
       raise "Bits must either: #{VALID_BITS[type.downcase].join(', ')}" unless VALID_BITS[type.downcase].nil? || VALID_BITS[type.downcase].include?(bits)
 
       case type.downcase
-      when "rsa" then new(OpenSSL::PKey::RSA.generate(bits).to_pem(cipher, options[:passphrase]), options)
-      when "dsa" then new(OpenSSL::PKey::DSA.generate(bits).to_pem(cipher, options[:passphrase]), options)
+      when "rsa"
+        key_object = OpenSSL::PKey::RSA.generate(bits)
+
+      when "dsa"
+        key_object = OpenSSL::PKey::DSA.generate(bits)
+
       when "ecdsa"
         # jruby-openssl OpenSSL::PKey::EC support isn't complete
         # https://github.com/jruby/jruby-openssl/issues/189
         jruby_not_implemented("OpenSSL::PKey::EC is not fully implemented")
 
-        new(OpenSSL::PKey::EC.new(ECDSA_CURVES[bits]).generate_key.to_pem(cipher, options[:passphrase]), options)
+        if OpenSSL::OPENSSL_VERSION_NUMBER >= 0x30000000
+          # https://github.com/ruby/openssl/pull/480
+          key_object = OpenSSL::PKey::EC.generate(ECDSA_CURVES[bits])
+        else
+          key_pkey = OpenSSL::PKey::EC.new(ECDSA_CURVES[bits])
+          key_object = key_pkey.generate_key
+        end
+
       else
         raise "Unknown key type: #{type}"
       end
 
+      key_pem = key_object.to_pem(cipher, options[:passphrase])
+      new(key_pem, options)
     end
 
     # Validate an existing SSH public key
@@ -424,9 +437,44 @@ class SSHKey
 
   def public_key_object
     if type == "ecdsa"
-      pub = OpenSSL::PKey::EC.new(key_object.group)
-      pub.public_key = key_object.public_key
-      pub
+      return nil unless key_object
+      return nil unless key_object.group
+
+      if OpenSSL::OPENSSL_VERSION_NUMBER >= 0x30000000
+        # Avoid "OpenSSL::PKey::PKeyError: pkeys are immutable on OpenSSL 3.0"
+        # https://github.com/ruby/openssl/blob/master/History.md#version-300
+        # https://github.com/ruby/openssl/issues/498
+        # https://github.com/net-ssh/net-ssh/commit/4de6831dea4e922bf3052192eec143af015a3486
+        # https://github.com/ClearlyClaire/cose-ruby/commit/28ee497fa7d9d49e72d5a5e97a567c0b58fdd822
+
+        curve_name = key_object.group.curve_name
+        return nil unless curve_name
+
+        # Construct public key OpenSSL::PKey::EC from OpenSSL::PKey::EC::Point
+        public_key_point = key_object.public_key  # => OpenSSL::PKey::EC::Point
+        return nil unless public_key_point
+
+        asn1 = OpenSSL::ASN1::Sequence(
+          [
+            OpenSSL::ASN1::Sequence(
+              [
+                OpenSSL::ASN1::ObjectId("id-ecPublicKey"),
+                OpenSSL::ASN1::ObjectId(curve_name)
+              ]
+            ),
+            OpenSSL::ASN1::BitString(public_key_point.to_octet_string(:uncompressed))
+          ]
+        )
+
+        pub = OpenSSL::PKey::EC.new(asn1.to_der)
+        pub
+
+      else
+        pub = OpenSSL::PKey::EC.new(key_object.group)
+        pub.public_key = key_object.public_key
+        pub
+      end
+
     else
       key_object.public_key
     end

--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -14,7 +14,7 @@ class OpenSSL::PKey::EC
     # NOTE: Unable to find these constants within OpenSSL, so hardcode them here.
     # Analogous to net-ssh OpenSSL::PKey::EC::CurveNameAliasInv
     # https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/transport/openssl.rb#L147-L151
-    case public_key.group.curve_name
+    case group.curve_name
     when "prime256v1" then "nistp256"  # https://stackoverflow.com/a/41953717
     when "secp256r1"  then "nistp256"  # JRuby
     when "secp384r1"  then "nistp384"
@@ -29,7 +29,7 @@ class OpenSSL::PKey::EC
     # https://github.com/jruby/jruby-openssl/issues/226
     jruby_not_implemented("to_octet_string is not implemented")
 
-    public_key.to_octet_string(:uncompressed)
+    public_key.to_octet_string(group.point_conversion_form)
   end
 end
 
@@ -463,7 +463,7 @@ class SSHKey
                 OpenSSL::ASN1::ObjectId(curve_name)
               ]
             ),
-            OpenSSL::ASN1::BitString(public_key_point.to_octet_string(:uncompressed))
+            OpenSSL::ASN1::BitString(public_key_point.to_octet_string(key_object.group.point_conversion_form))
           ]
         )
 

--- a/lib/sshkey.rb
+++ b/lib/sshkey.rb
@@ -12,7 +12,8 @@ end
 class OpenSSL::PKey::EC
   def identifier
     # NOTE: Unable to find these constants within OpenSSL, so hardcode them here.
-    # Curve names can be inferred from https://github.com/ruby/openssl/blob/master/ext/openssl/openssl_missing.c
+    # Analogous to net-ssh OpenSSL::PKey::EC::CurveNameAliasInv
+    # https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/transport/openssl.rb#L147-L151
     case public_key.group.curve_name
     when "prime256v1" then "nistp256"  # https://stackoverflow.com/a/41953717
     when "secp256r1"  then "nistp256"  # JRuby


### PR DESCRIPTION
Hi @bensie an update to Ubuntu jammy forced the use of [OpenSSL 3.0.2](https://github.com/ruby/openssl/blob/master/History.md#version-302), so I have added necessary ECDSA changes to support that. The gem remains backward-compatible with previous versions of OpenSSL. The test suite succeeds locally on all Ruby versions I was able to install: ruby-2.5.8, ruby-2.6.6, ruby-2.7.6, ruby-3.0.0, ruby-3.1.2

In making these changes, I emulated existing examples:

- gem [net-ssh](https://github.com/net-ssh/net-ssh/commit/4de6831dea4e922bf3052192eec143af015a3486)
- gem [ruby-openssl issue #498](https://github.com/ruby/openssl/issues/498)
- gem [ruby-openssl PR #480](https://github.com/ruby/openssl/pull/480/files)
- gem [cose-ruby](https://github.com/cedarcode/cose-ruby/commit/530db2f061e920d974327eba16099cf391d42cb)
- analogous gem [putty-key](https://github.com/philr/putty-key/commit/0585f7ac0b833534ff0d1128a3eb5036e972fe3e) to a lesser extent

In addition, there are a couple of minor improvements unrelated to OpenSSL 3:

- Extend comments to include mention of ECDSA
- Generalized hardcoded :uncompressed (even though [RFC8422](https://www.ietf.org/rfc/rfc8422.txt) says "This byte string may represent an elliptic curve point in uncompressed, compressed, or hybrid format, but this specification deprecates all but the uncompressed format.")

